### PR TITLE
SOCD detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ x64/*
 *.suobackup
 *.VC.db
 /.cache
+/tools/vs/.vs/
+/tools/vs/ktx/x64/
+/tools/vs/x64/

--- a/include/progs.h
+++ b/include/progs.h
@@ -944,6 +944,17 @@ typedef struct gedict_s
 	float fIllegalFPSWarnings;
 // ILLEGALFPS]
 
+// SOCD detectioin
+	float fStrafeChangeCount;
+	float fFramePerfectStrafeChangeCount;
+	int   socdDetected;
+	int   socdChecksCount;
+	float fLastSideMoveSpeed;
+	int   matchStrafeChangeCount;
+	int   matchPerfectStrafeCount;
+	int   nullStrafeCount;
+// SOCD
+
 	float shownick_time;					// used to force centerprint is off at desired time
 	clientType_t ct;						// client type for client edicts
 // { timing

--- a/src/commands.c
+++ b/src/commands.c
@@ -8114,14 +8114,42 @@ void fcheck()
 
 	if (!is_real_adm(self))
 	{
-		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server"))
+		if (strneq(arg_x, "f_version") && strneq(arg_x, "f_modified") && strneq(arg_x, "f_server") && strneq(arg_x, "f_movement"))
 		{
 			G_sprint(self, 2, "You are not allowed to check \020%s\021\n"
-						"available checks are: f_version, f_modified and f_server\n",
+						"available checks are: f_version, f_modified, f_server and f_movement\n",
 						arg_x);
 
 			return;
 		}
+	}
+
+	if (streq(arg_x, "f_movement"))
+	{
+		G_bprint(2, "%s is checking \020%s\021\n", self->netname, arg_x);
+
+		for (i = 1; i <= MAX_CLIENTS; i++)
+		{
+			if (!strnull(g_edicts[i].netname))
+			{
+				if (g_edicts[i].socdDetected > 0)
+				{
+					G_bprint(2, "%s: SOCD movement assistance detected!\n", g_edicts[i].netname);
+				}
+				else
+				{
+					if (g_edicts[i].socdChecksCount >= 2)
+					{
+						G_bprint(2, "%s: no assistance detected.\n", g_edicts[i].netname);
+					}
+					else
+					{
+						G_bprint(2, "%s: not enough movement to run SOCD detection. Please move around a map.\n", g_edicts[i].netname);
+					}
+				}
+			}
+		}
+		return;
 	}
 
 	for (i = 1; i <= MAX_CLIENTS; i++)

--- a/src/stats.c
+++ b/src/stats.c
@@ -763,6 +763,14 @@ void OnePlayerStats(gedict_t *p, int tp)
 					p->ps.vel_frames > 0 ? p->ps.velocity_sum / p->ps.vel_frames : 0.);
 	}
 
+	if (!p->isBot)
+	{
+		G_bprint(2, "%s: %s:%d/%d %s:%d/%d\n", redtext("Movement"), redtext("Perfect strafes"),
+			p->matchPerfectStrafeCount, p->matchStrafeChangeCount, redtext("SOCD detections"),
+			p->socdDetected, p->socdChecksCount);
+	}
+
+
 	// armors + megahealths
 	if (!lgc_enabled())
 	{

--- a/src/world.c
+++ b/src/world.c
@@ -1000,6 +1000,8 @@ void FirstFrame()
 
 	RegisterCvar("k_teamoverlay"); // q3 like team overlay
 
+	RegisterCvar("k_allow_socd_warning"); // socd
+
 // { SP
 	RegisterCvarEx("k_monster_spawn_time", "20");
 // }

--- a/tools/vs/ktx.vcxproj
+++ b/tools/vs/ktx.vcxproj
@@ -71,16 +71,16 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <TargetName>qwprogs.dll</TargetName>
+    <TargetName>qwprogs</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <TargetName>qwprogs.dll</TargetName>
+    <TargetName>qwprogs</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <TargetName>qwprogs.dll</TargetName>
+    <TargetName>qwprogs</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <TargetName>qwprogs.dll</TargetName>
+    <TargetName>qwprogs</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -91,7 +91,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\Users\Toma\source\repos\ktx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
@@ -111,7 +111,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\Users\Toma\source\repos\ktx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
@@ -131,7 +131,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\Users\Toma\source\repos\ktx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
@@ -151,7 +151,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>
       </PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>C:\Users\Toma\source\repos\ktx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderOutputFile />
     </ClCompile>
     <Link>
@@ -163,6 +163,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\include\bg_lib.h" />
     <ClInclude Include="..\..\include\deathtype.h" />
     <ClInclude Include="..\..\include\fb_globals.h" />
     <ClInclude Include="..\..\include\g_consts.h" />
@@ -174,6 +175,10 @@
     <ClInclude Include="..\..\include\progdefs.h" />
     <ClInclude Include="..\..\include\progs.h" />
     <ClInclude Include="..\..\include\q_shared.h" />
+    <ClInclude Include="..\..\include\rng.h" />
+    <ClInclude Include="..\..\include\rng_gen_impl.h" />
+    <ClInclude Include="..\..\include\rng_gen_state.h" />
+    <ClInclude Include="..\..\include\rng_seed_impl.h" />
     <ClInclude Include="..\..\include\stats.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="pch.h" />
@@ -181,6 +186,12 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\admin.c" />
     <ClCompile Include="..\..\src\arena.c" />
+    <ClCompile Include="..\..\src\bg_lib.c">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\..\src\bot_aim.c" />
     <ClCompile Include="..\..\src\bot_blocked.c" />
     <ClCompile Include="..\..\src\bot_botenemy.c" />
@@ -215,6 +226,8 @@
     <ClCompile Include="..\..\src\doors.c" />
     <ClCompile Include="..\..\src\fb_globals.c" />
     <ClCompile Include="..\..\src\files.c" />
+    <ClCompile Include="..\..\src\func_bob.c" />
+    <ClCompile Include="..\..\src\func_laser.c" />
     <ClCompile Include="..\..\src\globals.c" />
     <ClCompile Include="..\..\src\grapple.c" />
     <ClCompile Include="..\..\src\g_cmd.c" />
@@ -222,8 +235,10 @@
     <ClCompile Include="..\..\src\g_mem.c" />
     <ClCompile Include="..\..\src\g_spawn.c" />
     <ClCompile Include="..\..\src\g_syscalls.c" />
+    <ClCompile Include="..\..\src\g_syscalls_extra.c" />
     <ClCompile Include="..\..\src\g_userinfo.c" />
     <ClCompile Include="..\..\src\g_utils.c" />
+    <ClCompile Include="..\..\src\hiprot.c" />
     <ClCompile Include="..\..\src\hoonymode.c" />
     <ClCompile Include="..\..\src\items.c" />
     <ClCompile Include="..\..\src\logs.c" />
@@ -244,6 +259,9 @@
     <ClCompile Include="..\..\src\player.c" />
     <ClCompile Include="..\..\src\q_shared.c" />
     <ClCompile Include="..\..\src\race.c" />
+    <ClCompile Include="..\..\src\rng.c" />
+    <ClCompile Include="..\..\src\rng_gen_impl.c" />
+    <ClCompile Include="..\..\src\rng_seed_impl.c" />
     <ClCompile Include="..\..\src\route_calc.c" />
     <ClCompile Include="..\..\src\route_fields.c" />
     <ClCompile Include="..\..\src\route_lookup.c" />


### PR DESCRIPTION
1) Automatic warning if the server detects SOCD (can be enabled or disabled by the admin by modifying k_allow_socd_warning)
2) Command to check f_movement, summarizing for each player if the server detected anything. (ex: cmd check f_movement)
3) End-of-game stats to show if SOCD was in use.